### PR TITLE
Add circleci 2.0 and PR template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+# Use Circle CI 2.0
+version: 2
+## Customize the test machine
+jobs:
+  build:
+      working_directory: ~/electron-angular2-starter
+      docker:
+        - image: circleci/node:6.11.0-browsers
+          environment:
+            TZ: "/usr/share/zoneinfo/America/Chicago" # Set the timezone to Central
+      steps:
+        - checkout
+#        - run:
+#            name: update-npm
+#            command: sudo npm install -g npm@5.2.0
+        - run:
+            name: install-angular-cli
+            command: sudo npm install -g @angular/cli
+        - restore_cache:
+              key: node-6-dependency-cache-{{ .Branch }}-{{ checksum "package.json" }}
+        - run:
+            name: install-npm-dependencies
+            command: npm install
+        - save_cache:
+            key: node-6-dependency-cache-{{ .Branch }}-{{ checksum "package.json" }}
+            paths:
+              - ./node_modules
+#        - run:
+#            name: install-gem-dependencies
+#            command: gem install coveralls coveralls-lcov
+        - run:
+            name: unit-tests
+            command: ng test --single-run
+        - run:
+            name: e2e-tests
+            command: ng e2e

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Purpose
+
+#### What does this PR do?
+
+#### Where should the reviewer start?
+
+#### What are the relevant tickets?
+
+## Background and Context
+
+## Screenshots (if appropriate/for Design Acceptance)
+
+## Future Work
+
+#### Pre-flight Check List
+- [ ] Story has been marked as "complete".
+- [ ] The Wiki has been updated.
+- [ ] New NPM dependencies have been added to `package.json`
+- [ ] Does this pass design acceptance?


### PR DESCRIPTION
- Migrates CircleCI from 1.0 to 2.0. Taken from my [electron-angular2-starter](https://github.com/AlexSwensen/electron-angular2-starter)
- Adds Pull Request Template